### PR TITLE
installing executables with 'go get' is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ assets page.
 ### Via Go
 
 ```bash
-go get -u github.com/six-ddc/plow
+go install github.com/six-ddc/plow@latest
 ```
 
 ### Via Homebrew


### PR DESCRIPTION
go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation