### PR TITLE
Fixed jsonFormat typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ A high-performance HTTP benchmarking tool with real-time web UI and terminal dis
 Examples:
 
   plow http://127.0.0.1:8080/ -c 20 -n 100000
-  plow https://httpbin.org/post -c 20 -d 5m --body @file.jsonFormat -T 'application/jsonFormat' -m POST
+  plow https://httpbin.org/post -c 20 -d 5m --body @file.json -T 'application/json' -m POST
 
 Flags:
       --help                   Show context-sensitive help.

--- a/charts.go
+++ b/charts.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	_ "embed"
+
 	cors "github.com/AdhityaRamadhanus/fasthttpcors"
 	"github.com/go-echarts/go-echarts/v2/charts"
 	"github.com/go-echarts/go-echarts/v2/components"
@@ -42,7 +43,7 @@ function {{ .ViewID }}_sync() {
     $.ajax({
         type: "GET",
         url: "{{ .APIPath }}{{ .Route }}",
-        dataType: "jsonFormat",
+        dataType: "json",
         success: function (result) {
             let opt = goecharts_{{ .ViewID }}.getOption();
             let x = opt.xAxis[0].data;
@@ -141,8 +142,8 @@ func (c *Charts) newRPSView() components.Charter {
 }
 
 type Metrics struct {
-	Values []interface{} `jsonFormat:"values"`
-	Time   string        `jsonFormat:"time"`
+	Values []interface{} `json:"values"`
+	Time   string        `json:"time"`
 }
 
 type Charts struct {

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ var CompactUsageTemplate = `{{define "FormatCommand" -}}
 Examples:
 
   plow http://127.0.0.1:8080/ -c 20 -n 100000
-  plow https://httpbin.org/post -c 20 -d 5m --body @file.jsonFormat -T 'application/jsonFormat' -m POST
+  plow https://httpbin.org/post -c 20 -d 5m --body @file.json -T 'application/json' -m POST
 
 {{if .Context.Flags -}}
 {{T "Flags:"}}


### PR DESCRIPTION
Hi,

It seems some refactoring created a typo with "json" -> "jsonFormat" and it breaks the UI
I think these changes fix the issue.